### PR TITLE
Add test for simple P/D/I hierarchy duplication

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -165,6 +165,11 @@ class TestDuplicate(CLITest):
         self.args += ['Project:%s' % proj.id.val]
         self.duplicate(capfd)
 
+        pp = omero.sys.ParametersI()
+        pp.addString("name", namep)
+        query = "select obj from Project obj where obj.name=:name"
+        objsp = self.query.findAllByQuery(query, pp)
+
         pd = omero.sys.ParametersI()
         pd.addString("name", named)
         query = "select obj from Dataset obj where obj.name=:name"
@@ -190,6 +195,10 @@ class TestDuplicate(CLITest):
         assert objsi[0].id.val != objsi[1].id.val
 
         # Check that the duplicated Dataset/Image is linked
-        # only to the duplicated Project/Dataset
+        # only to pne and just one Project/Dataset
         assert len(proj_linked) == 1
         assert len(dat_linked) == 1
+
+        # Check that the linked Project/Dataset are the duplicated ones
+        assert dat_linked[0].id.val == did
+        assert proj_linked[0].id.val == max(objsp[0].id.val, objsp[1].id.val)

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -169,6 +169,8 @@ class TestDuplicate(CLITest):
         query = "select obj from Project obj where obj.name=:name"
         objsp = self.query.findAllByQuery(query, pp)
 
+        assert len(objsp) == 2
+
         pd = omero.sys.ParametersI()
         pd.addString("name", named)
         query = "select obj from Dataset obj where obj.name=:name"

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -176,8 +176,8 @@ class TestDuplicate(CLITest):
 
         pid = max(objsp[0].id.val, objsp[1].id.val)
 
-        # Check the duplicated Project ID is in the --report output
-        assert str(pid) in out
+        # Check the duplicated Project is in the --report output
+        assert 'Project:%s' % pid in out
 
         pd = omero.sys.ParametersI()
         pd.addString("name", named)
@@ -192,8 +192,8 @@ class TestDuplicate(CLITest):
         did = max(objsd[0].id.val, objsd[1].id.val)
         proj_linked = self.get_project(did)
 
-        # Check the duplicated Dataset ID is in the --report output
-        assert str(did) in out
+        # Check the duplicated Dataset is in the --report output
+        assert 'Dataset:%s' % did in out
 
         # Check the duplicated Dataset is linked to just the duplicated Project
         assert len(proj_linked) == 1
@@ -212,8 +212,8 @@ class TestDuplicate(CLITest):
         iid = max(objsi[0].id.val, objsi[1].id.val)
         dat_linked = self.get_dataset(iid)
 
-        # Check the duplicated Image ID is in the --report output
-        assert str(iid) in out
+        # Check the duplicated Image is in the --report output
+        assert 'Image:%s' % iid in out
 
         # Check the duplicated image is linked to just the duplicated Dataset
         assert len(dat_linked) == 1

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -44,10 +44,9 @@ class TestDuplicate(CLITest):
 
         params = omero.sys.ParametersI()
         params.addId(iid)
-        query = "select d from Dataset as d"
-        query += " where exists ("
-        query += " select l from DatasetImageLink as l"
-        query += " where l.child.id=:id and l.parent=d.id) "
+        query = ("select d from Dataset as d where exists"
+                 "(select l from DatasetImageLink as l where "
+                 "l.child.id=:id and l.parent=d.id)")
         return self.query.findAllByQuery(query, params)
 
     def get_project(self, did):

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -169,16 +169,18 @@ class TestDuplicate(CLITest):
         query = "select obj from Project obj where obj.name=:name"
         objsp = self.query.findAllByQuery(query, pp)
 
-        # Check that there are 2 Projects, the original and the duplicate
+        # Check the Project has been duplicated
         assert len(objsp) == 2
+        assert objsp[0].id.val != objsp[1].id.val
 
         pd = omero.sys.ParametersI()
         pd.addString("name", named)
         query = "select obj from Dataset obj where obj.name=:name"
         objsd = self.query.findAllByQuery(query, pd)
 
-        # Check there are 2 Datasets
+        # Check the Dataset has been duplicated
         assert len(objsd) == 2
+        assert objsd[0].id.val != objsd[1].id.val
 
         # Find the Projects linked to the duplicated dataset
         did = max(objsd[0].id.val, objsd[1].id.val)
@@ -193,19 +195,14 @@ class TestDuplicate(CLITest):
         query = "select obj from Image obj where obj.name=:name"
         objsi = self.query.findAllByQuery(query, pi)
 
+        # Check the image has been duplicated
+        assert len(objsi) == 2
+        assert objsi[0].id.val != objsi[1].id.val
+
         # Find the Datasets linked to the duplicated image
         iid = max(objsi[0].id.val, objsi[1].id.val)
         dat_linked = self.get_dataset(iid)
 
-        # Check that the Dataset and Image were duplicated
-        assert len(objsi) == 2
-        assert objsd[0].id.val != objsd[1].id.val
-        assert objsi[0].id.val != objsi[1].id.val
-
-        # Check that the duplicated Dataset/Image is linked
-        # only to pne and just one Project/Dataset
-
+        # Check the duplicated image is linked to just the duplicated Dataset
         assert len(dat_linked) == 1
-
-        # Check that the linked Project/Dataset are the duplicated ones
         assert dat_linked[0].id.val == did

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -39,6 +39,28 @@ class TestDuplicate(CLITest):
         self.cli.invoke(self.args, strict=True)
         return capfd.readouterr()[0]
 
+    def get_dataset(self, iid):
+        """Retrieve all the parent datasets linked to the image"""
+
+        params = omero.sys.ParametersI()
+        params.addId(iid)
+        query = "select d from Dataset as d"
+        query += " where exists ("
+        query += " select l from DatasetImageLink as l"
+        query += " where l.child.id=:id and l.parent=d.id) "
+        return self.query.findAllByQuery(query, params)
+
+    def get_project(self, did):
+        """Retrieve all the parent projects linked to the dataaset"""
+
+        params = omero.sys.ParametersI()
+        params.addId(did)
+        query = "select p from Project as p"
+        query += " where exists ("
+        query += " select l from ProjectDatasetLink as l"
+        query += " where l.child.id=:id and l.parent=p.id) "
+        return self.query.findAllByQuery(query, params)
+
     @pytest.mark.parametrize("model", model)
     @pytest.mark.parametrize("object_type", object_types)
     def testDuplicateSingleObject(self, object_type, model, capfd):
@@ -128,3 +150,46 @@ class TestDuplicate(CLITest):
         assert '%s:%s' % (object_type, objs[0].id.val) in out
         # Check object has been found in two different places of the output
         assert out.find(obj_arg) != out.rfind(obj_arg)
+
+    def testBasicHierarchyDuplication(self, capfd):
+        namep = self.uuid()
+        named = self.uuid()
+        namei = self.uuid()
+        proj = self.make_project(namep)
+        dset = self.make_dataset(named)
+        img = self.make_image(namei)
+
+        self.link(proj, dset)
+        self.link(dset, img)
+
+        self.args += ['Project:%s' % proj.id.val]
+        self.duplicate(capfd)
+
+        pd = omero.sys.ParametersI()
+        pd.addString("name", named)
+        query = "select obj from Dataset obj where obj.name=:name"
+        objsd = self.query.findAllByQuery(query, pd)
+
+        # Find the Projects linked to the duplicated dataset
+        did = max(objsd[0].id.val, objsd[1].id.val)
+        proj_linked = self.get_project(did)
+
+        pi = omero.sys.ParametersI()
+        pi.addString("name", namei)
+        query = "select obj from Image obj where obj.name=:name"
+        objsi = self.query.findAllByQuery(query, pi)
+
+        # Find the Datasets linked to the duplicated image
+        iid = max(objsi[0].id.val, objsi[1].id.val)
+        dat_linked = self.get_dataset(iid)
+
+        # Check that the Dataset and Image were duplicated
+        assert len(objsd) == 2
+        assert len(objsi) == 2
+        assert objsd[0].id.val != objsd[1].id.val
+        assert objsi[0].id.val != objsi[1].id.val
+
+        # Check that the duplicated Dataset/Image is linked
+        # only to the duplicated Project/Dataset
+        assert len(proj_linked) == 1
+        assert len(dat_linked) == 1

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -169,6 +169,7 @@ class TestDuplicate(CLITest):
         query = "select obj from Project obj where obj.name=:name"
         objsp = self.query.findAllByQuery(query, pp)
 
+        # Check that there are 2 Projects, the original and the duplicate
         assert len(objsp) == 2
 
         pd = omero.sys.ParametersI()
@@ -176,9 +177,16 @@ class TestDuplicate(CLITest):
         query = "select obj from Dataset obj where obj.name=:name"
         objsd = self.query.findAllByQuery(query, pd)
 
+        # Check there are 2 Datasets
+        assert len(objsd) == 2
+
         # Find the Projects linked to the duplicated dataset
         did = max(objsd[0].id.val, objsd[1].id.val)
         proj_linked = self.get_project(did)
+
+        # Check the duplicated Dataset is linked to just the duplicated Project
+        assert len(proj_linked) == 1
+        assert proj_linked[0].id.val == max(objsp[0].id.val, objsp[1].id.val)
 
         pi = omero.sys.ParametersI()
         pi.addString("name", namei)
@@ -190,16 +198,14 @@ class TestDuplicate(CLITest):
         dat_linked = self.get_dataset(iid)
 
         # Check that the Dataset and Image were duplicated
-        assert len(objsd) == 2
         assert len(objsi) == 2
         assert objsd[0].id.val != objsd[1].id.val
         assert objsi[0].id.val != objsi[1].id.val
 
         # Check that the duplicated Dataset/Image is linked
         # only to pne and just one Project/Dataset
-        assert len(proj_linked) == 1
+
         assert len(dat_linked) == 1
 
         # Check that the linked Project/Dataset are the duplicated ones
         assert dat_linked[0].id.val == did
-        assert proj_linked[0].id.val == max(objsp[0].id.val, objsp[1].id.val)

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -54,10 +54,9 @@ class TestDuplicate(CLITest):
 
         params = omero.sys.ParametersI()
         params.addId(did)
-        query = "select p from Project as p"
-        query += " where exists ("
-        query += " select l from ProjectDatasetLink as l"
-        query += " where l.child.id=:id and l.parent=p.id) "
+        query = ("select p from Project as p where exists"
+                 "(select l from ProjectDatasetLink as l where "
+                 "l.child.id=:id and l.parent=p.id)")
         return self.query.findAllByQuery(query, params)
 
     @pytest.mark.parametrize("model", model)

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -162,7 +162,8 @@ class TestDuplicate(CLITest):
         self.link(dset, img)
 
         self.args += ['Project:%s' % proj.id.val]
-        self.duplicate(capfd)
+        self.args += ['--report']
+        out = self.duplicate(capfd)
 
         pp = omero.sys.ParametersI()
         pp.addString("name", namep)
@@ -172,6 +173,11 @@ class TestDuplicate(CLITest):
         # Check the Project has been duplicated
         assert len(objsp) == 2
         assert objsp[0].id.val != objsp[1].id.val
+
+        pid = max(objsp[0].id.val, objsp[1].id.val)
+
+        # Check the duplicated Project ID is in the --report output
+        assert str(pid) in out
 
         pd = omero.sys.ParametersI()
         pd.addString("name", named)
@@ -186,9 +192,12 @@ class TestDuplicate(CLITest):
         did = max(objsd[0].id.val, objsd[1].id.val)
         proj_linked = self.get_project(did)
 
+        # Check the duplicated Dataset ID is in the --report output
+        assert str(did) in out
+
         # Check the duplicated Dataset is linked to just the duplicated Project
         assert len(proj_linked) == 1
-        assert proj_linked[0].id.val == max(objsp[0].id.val, objsp[1].id.val)
+        assert proj_linked[0].id.val == pid
 
         pi = omero.sys.ParametersI()
         pi.addString("name", namei)
@@ -202,6 +211,9 @@ class TestDuplicate(CLITest):
         # Find the Datasets linked to the duplicated image
         iid = max(objsi[0].id.val, objsi[1].id.val)
         dat_linked = self.get_dataset(iid)
+
+        # Check the duplicated Image ID is in the --report output
+        assert str(iid) in out
 
         # Check the duplicated image is linked to just the duplicated Dataset
         assert len(dat_linked) == 1


### PR DESCRIPTION
This is adding the simple P/D/I hierarchy duplication test. It tests whether all 3 objects were duplicated and it tests whether the linkage between the duplicated P-D-I is as expected (only one link should  exist between the new D and any P, and this one must be the new P, only one link shoiuld exist between the new I and any D, and this one must be the new D).
Please let me know if it makes sense.
